### PR TITLE
Add responsive hamburger menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
 <body>
   <header>
     <h1>Footage Paintings</h1>
+    <button class="menu-toggle" aria-label="Toggle navigation">&#9776;</button>
     <nav>
       <ul>
         <li><a href="#statement">Statement</a></li>

--- a/script.js
+++ b/script.js
@@ -1,4 +1,11 @@
 document.addEventListener('DOMContentLoaded', () => {
+  const toggle = document.querySelector('.menu-toggle');
+  const nav = document.querySelector('nav');
+  if (toggle && nav) {
+    toggle.addEventListener('click', () => {
+      nav.classList.toggle('open');
+    });
+  }
   document.querySelectorAll('.grid img').forEach(img => {
     img.addEventListener('click', () => {
       const overlay = document.createElement('div');

--- a/style.css
+++ b/style.css
@@ -14,6 +14,17 @@ header {
   border-bottom: 1px solid #eee;
 }
 
+.menu-toggle {
+  display: none;
+  background: none;
+  border: none;
+  font-size: 1.5rem;
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+  cursor: pointer;
+}
+
 nav ul {
   list-style: none;
   margin: 0;
@@ -98,4 +109,27 @@ footer {
 .overlay img {
   max-width: 90%;
   max-height: 90%;
+}
+
+@media (max-width: 768px) {
+  header {
+    position: relative;
+  }
+  nav ul {
+    flex-direction: column;
+    gap: 0.5rem;
+    position: absolute;
+    top: 100%;
+    right: 0;
+    background: #fff;
+    padding: 1rem;
+    box-shadow: 0 2px 6px rgba(0,0,0,0.1);
+    display: none;
+  }
+  nav.open ul {
+    display: flex;
+  }
+  .menu-toggle {
+    display: block;
+  }
 }


### PR DESCRIPTION
## Summary
- add hamburger button for mobile layouts
- style menu for small screens
- toggle navigation with JavaScript

## Testing
- `python3 -m http.server 8000`

------
https://chatgpt.com/codex/tasks/task_e_688a5afb235483338225c6cb5a903032